### PR TITLE
all 'carts' properly destroyed after successful purchase

### DIFF
--- a/server/api/cart.js
+++ b/server/api/cart.js
@@ -77,7 +77,7 @@ router.put('/:userId/:productId/:quantity', async (req, res, next) => {
   } catch (error) {
     next(error)
   }
-})  
+})
 router.delete('/guest/:item', (req, res, next) => {
   const itemTodelete = req.params.item
   delete req.session.cart[itemTodelete]
@@ -105,6 +105,7 @@ router.delete('/:userId/:productId', async (req, res, next) => {
 
 router.delete('/guest', async (req, res, next) => {
   try {
+    console.log('req.session.cart is', req.session.cart)
     delete req.session.cart
     res.status(204).send([])
   } catch (err) {
@@ -126,12 +127,11 @@ router.get('/guest', (req, res, next) => {
 
 router.delete('/:userId', async (req, res, next) => {
   try {
-    const cart = await Cart.findOne({
+    await Cart.destroy({
       where: {
         userId: req.params.userId
       }
     })
-    await cart.destroy()
     res.status(204).send([])
   } catch (err) {
     next(err)


### PR DESCRIPTION
Fixed bug where, after successful purchase, it would only delete one type of product from cart instead of whole cart